### PR TITLE
[Fixed a bug] returns empty array when no tags are found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Changelog
 
+## [0.2.0] - 2021-05-07
+
+### Added
+
+- Return empty array if no tags are found
+
 ## [0.1.0] - 2021-05-06
 
 ### Added
+
 - Find all tags in the system
 - Find all tags on a file
 - Find files by tag

--- a/lib/macos-tags.rb
+++ b/lib/macos-tags.rb
@@ -120,7 +120,7 @@ module MacosTags
     end
 
     def tags
-      parse_raw_tags.value.map do |raw_tag|
+      (parse_raw_tags&.value || []).map do |raw_tag|
         label, color_val = raw_tag.value.split("\n")
         Tag.new(label: label, color: Color.new(color_val.to_i))
       end
@@ -129,7 +129,9 @@ module MacosTags
     private
 
     def parse_raw_tags
-      plist.load_binary_str(xattr[XATTR_TAGS])
+      if xattr[XATTR_TAGS]
+        plist.load_binary_str(xattr[XATTR_TAGS])
+      end
     end
   end
 end

--- a/tests/test_macos_tags.rb
+++ b/tests/test_macos_tags.rb
@@ -6,4 +6,12 @@ describe MacosTags do
       _(MacosTags.all_tags).must_be_kind_of(Array)
     end
   end
+
+  describe MacosTags::TagParser do
+    it "must returns empty list if no tags are found" do
+      Tempfile.create('tag_parser_test', '/tmp') do |f|
+        _(MacosTags::TagParser.new(f).tags).must_equal([])
+      end
+    end
+  end
 end


### PR DESCRIPTION
[Fixed a bug]
- returns empty array when no tags are found

## Notes

This change will be included in v0.2.0 release